### PR TITLE
feat: add PostHog analytics and update privacy policy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 _site/
 *.swp
 .tags
+*.zip

--- a/_includes/analytics-posthog.html
+++ b/_includes/analytics-posthog.html
@@ -1,0 +1,13 @@
+{% if jekyll.environment == "production" %}
+<!-- PostHog (anonymous, production only) -->
+<script>
+    !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Re Ms Fs Pe Rs Cs capture Ve calculateEventProperties Ds register register_once register_for_session unregister unregister_for_session zs getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ls As createPersonProfile Ns Is Us opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing is_capturing clear_opt_in_out_capturing Os debug I js getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+    posthog.init('phc_OFzgZaj280iQ34rFEptHd66zhTiaav7ZbXLly9puXLK', {
+        api_host: 'https://us.i.posthog.com',
+        defaults: '2025-05-24',
+        //person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
+        person_profiles: 'always', // or 'always' to create profiles for anonymous users as well
+    })
+</script>
+{% endif %}
+

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,5 +1,5 @@
 {% if jekyll.environment == "production" %}
-<!-- Google Tag Manager -->
+<!-- DISABLED Google Tag Manager 
 <script>
     (function (w, d, s, l, i) {
         w[l] = w[l] || [];
@@ -12,9 +12,12 @@
         f.parentNode.insertBefore(j, f);
     })(window, document, "script", "dataLayer", "GTM-N3339PFR");
 </script>
+-->
 <!-- End Google Tag Manager -->
 {% endif %}
 
+
+<!-- Cookie Consent (TEMP DISABLED)
 <link
     rel="stylesheet"
     href="https://cdn.jsdelivr.net/npm/cookieconsent@3/build/cookieconsent.min.css"
@@ -51,5 +54,7 @@
         }
     });
 </script>
+-->
+
 <link rel="icon" href="{{ '/favicon.ico' | relative_url }}" sizes="any" />
 <link rel="manifest" href="{{ '/site.webmanifest' | relative_url }}" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -58,7 +58,7 @@
     </head>
     <body>
         {% if jekyll.environment == "production" %}
-        <!-- Google Tag Manager (noscript) -->
+        <!-- DISABLED Google Tag Manager (noscript)
         <noscript
             ><iframe
                 src="https://www.googletagmanager.com/ns.html?id=GTM-N3339PFR"
@@ -67,7 +67,7 @@
                 style="display: none; visibility: hidden"
             ></iframe
         ></noscript>
-        <!-- End Google Tag Manager (noscript) -->
+        End DISABLED Google Tag Manager (noscript) -->
         {% endif %}
 
         <div id="header">
@@ -121,21 +121,21 @@
                     </button>
                 </form>
             </div> -->
-            <p style="text-align: center; margin: 0;">
-                    <span class="credits left"
-                        >Project maintained by
-                        <a href="{{ site.github.owner_url }}"
-                            >{{ site.github.owner_name }}</a
-                        ></span
-                    >
+            <p style="text-align: center; margin: 0">
+                <span class="credits left"
+                    >Project maintained by
+                    <a href="{{ site.github.owner_url }}"
+                        >{{ site.github.owner_name }}</a
+                    ></span
+                >
             </p>
-            <p style="text-align: center; margin: 0;">
-                    <span class="credits right"
-                        >Hosted on GitHub Pages &mdash; Theme by
-                        <a href="https://twitter.com/mattgraham"
-                            >mattgraham</a
-                        ></span
-                    >
+            <p style="text-align: center; margin: 0">
+                <span class="credits right"
+                    >Hosted on GitHub Pages &mdash; Theme by
+                    <a href="https://twitter.com/mattgraham"
+                        >mattgraham</a
+                    ></span
+                >
             </p>
             <p style="text-align: center">
                 &copy; {{ site.time | date: '%Y' }} {{ site.name }}. All rights
@@ -207,9 +207,10 @@
                 WaveDrom.ProcessAll();
             });
         </script>
-        <script
+        <!--        <script
             src="//code.tidio.co/l1wmxlfn2c7u77x4bcib8nmte3bqmbtq.js"
             async
-        ></script>
+        ></script>   -->
+        {% include analytics-posthog.html %}
     </body>
 </html>

--- a/_pages/privacy-policy.md
+++ b/_pages/privacy-policy.md
@@ -4,9 +4,87 @@ title: Privacy Policy
 permalink: /privacy-policy/
 ---
 
+## TL;DR
+
+This website collects limited, anonymous usage information to help us
+understand how visitors interact with the site and to improve the
+content and experience.
+
+- **Analytics:** We use [PostHog](https://posthog.com/) to track page
+  views and basic interactions. Data is collected without personally
+  identifying information and is used only in aggregate to see how the
+  site is used.
+
+- **No Cookies for Identification:** We do not use cookies or tracking
+  technologies to personally identify you when you visit this site.
+
+- **Conversations / Support:** At times, we may use tools to provide
+  live chat or collect questions from visitors. Any information you
+  choose to share through those channels is voluntary.
+
+- **Future Updates:** If you create an account or use related services
+  (for example, subscriptions or logins through our applications), we
+  may update this policy to reflect additional data we collect and how
+  it is used.
+
+If you have any questions about this Privacy Policy, please contact us
+at [privacy@francoisperron.ca](mailto:privacy@francoisperron.ca).
+
+
+---
+
 ## Privacy Policy
 
-This website uses cookies to provide the best experience. We also use
-Google Analytics to collect anonymous traffic data. We also use tidio
-to manage conversations.
+### Information We Collect
+- **Usage Data:** We collect anonymous information such as page views,
+  time spent on pages, and general navigation patterns using
+  [PostHog](https://posthog.com/).
+- **Support Data:** If you contact us directly (for example via email
+  or live chat), we may store the information you choose to provide to
+  respond to your request.
+
+### How We Use the Information
+- To understand how visitors interact with the site.
+- To improve the site’s design, content, and overall experience.
+- To respond to inquiries or support requests.
+
+### Cookies
+- This website does not use cookies or tracking technologies to
+  identify you personally.
+- Some analytics features may rely on local storage or session
+  storage, but only for anonymous event tracking.
+
+### Data Retention
+- Analytics data is stored for a limited period (generally no longer
+  than 12 months) and then deleted or aggregated.
+- Support communications are retained as long as necessary to provide
+  service and comply with applicable laws.
+
+### Sharing of Information
+- We do not sell or rent personal information.
+- We only share data with service providers (such as PostHog) who
+  process it on our behalf under strict confidentiality obligations.
+
+### Legal Basis for Processing (for EU Visitors)
+- **Legitimate Interest:** Collecting anonymous usage data helps us
+  improve the website without infringing on individual privacy.
+- **Consent:** If in the future we introduce cookies or personal data
+  collection, we will request explicit consent where required.
+
+### Your Rights
+Depending on your location (e.g. GDPR in the EU, PIPEDA in Canada), you
+may have the right to:
+- Request access to the data we hold about you.
+- Request correction or deletion of your data.
+- Restrict or object to processing of your data.
+- Lodge a complaint with your local data protection authority.
+
+To exercise these rights, please contact us at
+[privacy@francoisperron.ca](mailto:privacy@francoisperron.ca).
+
+### Updates
+This policy may change if we introduce new features such as
+authentication, subscriptions, or other services. We encourage you to
+review this page periodically for updates.
+
 

--- a/collate_jekyll.sh
+++ b/collate_jekyll.sh
@@ -1,50 +1,23 @@
 #!/bin/bash
+OUT="fx-portfolio-lite.zip"
 
-# Output file to hold the collated content
-COLLATED_FILE="jekyll_collated_files.txt"
+echo "Creating $OUT without heavy or dev-only files..."
 
-# List of files and directories to include
-INCLUDE_LIST=(
-  "_config.yml"
-  "Gemfile"
-  "Gemfile.lock"
-  "assets/theme/css/style.scss"
-  "assets/theme/css/ie.scss"
-  "_layouts/default.html"
-  "_includes/head-custom.html"
-  "_pages/about.md"
-  "_pages/portfolio.md"
-  "index.md"
-  "README.md"
-)
+zip -r "$OUT" . \
+  -x "_site/*" \
+  -x ".jekyll-cache/*" \
+  -x ".git/*" \
+  -x "*.DS_Store" \
+  -x "*.swp" \
+  -x "*.swo" \
+  -x "*.tags" \
+  -x "jekyll_collated_files.txt" \
+  -x "fx-portfolio.zip" \
+  -x "fx-portfolio-lite.zip" \
+  -x "assets/images/*" \
+  -x "assets/docs/*" \
+  -x "assets/fonts/*" \
+  -x "assets/theme/images/*"
 
-# Create a fresh output file
-> "$COLLATED_FILE"
-
-echo "Collating files into $COLLATED_FILE..."
-
-# Loop through the files and directories, appending their content
-for ITEM in "${INCLUDE_LIST[@]}"; do
-  if [ -f "$ITEM" ]; then
-    echo -e "\n\n===========================" >> "$COLLATED_FILE"
-    echo "FILE: $ITEM" >> "$COLLATED_FILE"
-    echo "===========================" >> "$COLLATED_FILE"
-    cat "$ITEM" >> "$COLLATED_FILE"
-  elif [ -d "$ITEM" ]; then
-    echo -e "\n\n===========================" >> "$COLLATED_FILE"
-    echo "DIRECTORY: $ITEM" >> "$COLLATED_FILE"
-    echo "===========================" >> "$COLLATED_FILE"
-    find "$ITEM" -type f | while read -r FILE; do
-      echo -e "\n\n--- FILE: $FILE ---" >> "$COLLATED_FILE"
-      cat "$FILE" >> "$COLLATED_FILE"
-    done
-  else
-    echo "Skipping missing item: $ITEM"
-  fi
-done
-
-echo "Done! All content is now in $COLLATED_FILE."
-
-# Display a message
-echo "You can open $COLLATED_FILE and copy its content here."
+echo "Done. Created $OUT"
 


### PR DESCRIPTION
- Integrate PostHog tracking (production only) via new include
- Disable Google Tag Manager and cookie consent scripts
- Update default layout to load PostHog include
- Add TL;DR and full rewritten privacy policy reflecting PostHog usage
- Replace collate script with lightweight zip packaging for sharing
- Extend .gitignore to exclude generated .zip files