### PR TITLE
feat: add app nname in person properties

### DIFF
--- a/_includes/analytics-posthog.html
+++ b/_includes/analytics-posthog.html
@@ -8,6 +8,28 @@
         //person_profiles: 'identified_only', // or 'always' to create profiles for anonymous users as well
         person_profiles: 'always', // or 'always' to create profiles for anonymous users as well
     })
+
+     // --- Persistent properties (stick across visits on this device) ---
+  posthog.register({
+    app: 'portfolio',                 // which app emitted this
+    site: 'fx-portfolio',             // human name
+    env: '{{ jekyll.environment }}',  // "production" for GH pages
+    baseurl: '{{ site.baseurl }}',    // e.g. /fx-portfolio
+    deploy_rev: '{{ site.github.build_revision | default: "v1.0" }}'
+  });
+
+  // --- Per-session properties (reset each new session/tab) ---
+  posthog.register_for_session({
+    host: location.host,
+    path: location.pathname,
+    ref: document.referrer || null
+  });
+
+  // --- Per-person properties (funnel stub) ---
+      posthog.setPersonProperties({
+    app: 'fx-portfolio'
+  })
+
 </script>
 {% endif %}
 


### PR DESCRIPTION
feat(analytics, privacy): switch to PostHog (prod-only), add policy; disable GTM/chat; add lite packaging

Summary
- Integrates PostHog analytics for production-only page views/interactions.
- Adds a clear, privacy-first policy page.
- Disables Google Tag Manager and cookie-consent for now.
- Removes live chat script (Tidio) from layout.
- Replaces collate script with a “lite” ZIP packager for sharing.
- Ignores ZIP artifacts in git.